### PR TITLE
moved customActionAttributes from ConnectivityActionBase to Connectiv…

### DIFF
--- a/package/cloudshell/cp/core/models.py
+++ b/package/cloudshell/cp/core/models.py
@@ -25,16 +25,16 @@ class ConnectivityActionBase(RequestActionBase):
     def __init__(self):
         RequestActionBase.__init__(self)
         self.actionTarget = None           # type: ActionTarget
-        self.customActionAttributes = None # type: dict
 
 class ConnectivityVlanActionBase(ConnectivityActionBase):
     def __init__(self):
         ConnectivityActionBase.__init__(self)
-        self.connectionId = ''          # type: str
-        self.connectionParams = None    # type: SetVlanParameter
-        self.connectorAttributes = None # type: dict
+        self.connectionId = ''             # type: str
+        self.connectionParams = None       # type: SetVlanParameter
+        self.connectorAttributes = None    # type: dict
+        self.customActionAttributes = None # type: dict
 
-#endregion
+    #endregion
 
 #region Common
 
@@ -76,9 +76,9 @@ class AppResourceInfo(RequestObjectBase):
 #endregion
 #region CreateKeys
 
-class CreateKeys(ConnectivityActionBase):
+class CreateKeys(RequestActionBase):
     def __init__(self):
-        ConnectivityActionBase.__init__(self)
+        RequestActionBase.__init__(self)
 
 #endregion
 #region PrepareSubnet


### PR DESCRIPTION
…ityVlanActionBase

CreateKeys now inherits RequestActionBase and not ConnectivityActionBase

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/cloudshell-cp-core/5)
<!-- Reviewable:end -->
