### PR TITLE
fixed a bug in custom model creation

### DIFF
--- a/package/cloudshell/cp/core/utils.py
+++ b/package/cloudshell/cp/core/utils.py
@@ -7,12 +7,21 @@ def set_value(target, name, value, raise_exeception = False):
     elif(not try_set_attr(target, name, value) and raise_exeception):
         raise ValueError(target.__class__.__name__ +  ' has no property named ' + name)
 
+def convert_to_bool(v):
+
+    if type(v) is bool:
+        return v
+
+    return v != None and v.lower() == "true"
+
 def try_set_attr(target, name, value):
 
     try:
         if (hasattr(target, name)):
+            value = convert_to_bool(value) if type(getattr(target, name)) is bool else value
             setattr(target, name, value)
             return True
+
     except Exception as e:
         pass
 

--- a/package/tests/test_cloudshell_cp_core.py
+++ b/package/tests/test_cloudshell_cp_core.py
@@ -36,8 +36,9 @@ class TestCloudShellCpCore(TestCase):
             __deploymentModel__ = "VCenter Deploy VM From Linked Clone"
 
             def __init__(self, attributes):
-                self.auto_power_off = ''
+                self.auto_power_off = False
                 self.autoload = ''
+
 
                 for k, v in attributes.iteritems():
                     try_set_attr(self, to_snake_case(k), v)
@@ -52,8 +53,9 @@ class TestCloudShellCpCore(TestCase):
         action = parser.convert_driver_request_to_actions(deploy_req_json)[0]
 
         # assert
-        self.assertTrue(action.actionParams.deployment.customModel.autoload, 'True')
-        self.assertTrue(action.actionParams.deployment.customModel.auto_power_off, 'True')
+        self.assertEqual(action.actionParams.deployment.customModel.autoload, 'True')
+        self.assertEqual(action.actionParams.deployment.customModel.auto_power_off, True)
+
 
     def test_deploy_app_action(self):
         # prepare
@@ -118,3 +120,14 @@ class TestCloudShellCpCore(TestCase):
         # assert
         self.assertTrue(len(actions) == 1)
         self.assertEqual(actions[0].actionParams.appName, 'vCenter_CVC_Support')
+
+    def test_try_set_attr(self):
+
+        class CustomModel(object):
+            __deploymentModel__ = "VCenter Deploy VM From Linked Clone"
+
+            def __init__(self, attributes):
+                self.auto_power_off = attributes['Auto Power Off']
+                self.autoload = attributes['Autoload']
+
+        atts_json = '[{"attributeName":"Auto Delete","attributeValue":"True","type":"attributes"},{"attributeName":"Autoload","attributeValue":"True","type":"attributes"},{"attributeName":"IP Regex","attributeValue":"","type":"attributes"},{"attributeName":"Refresh IP Timeout","attributeValue":"600","type":"attributes"},{"attributeName":"vCenter VM","attributeValue":"Tor/Temps/ImageMonoNew","type":"attributes"},{"attributeName":"vCenter VM Snapshot","attributeValue":"1","type":"attributes"},{"attributeName":"VM Cluster","attributeValue":"","type":"attributes"},{"attributeName":"VM Storage","attributeValue":"","type":"attributes"},{"attributeName":"VM Resource Pool","attributeValue":"","type":"attributes"},{"attributeName":"VM Location","attributeValue":"","type":"attributes"},{"attributeName":"Auto Power On","attributeValue":"True","type":"attributes"},{"attributeName":"Auto Power Off","attributeValue":"True","type":"attributes"},{"attributeName":"Wait for IP","attributeValue":"True","type":"attributes"}]'


### PR DESCRIPTION
because  of custom model , the way we parse it
before when it was hardcoded
this: "add_floating_ip": "False"
became boolean False now its becomes
"False"
and we check his value by:
if deploy_req_model.add_floating_ip:
that will now be resolved as True since its non empty string

fixed by checking for custom model property type before assigning  if its bool we try to parse string to bool

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/cloudshell-cp-core/22)
<!-- Reviewable:end -->
