### PR TITLE
Add support for parsing Private IPs attribute

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 
 python:
   - "2.7"
-  - "3.4"
+  - "3.7"
 
 #command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:

--- a/package/cloudshell/cp/core/drive_request_parser.py
+++ b/package/cloudshell/cp/core/drive_request_parser.py
@@ -2,6 +2,7 @@ import sys
 from cloudshell.cp.core.utils import  *
 from cloudshell.cp.core.models import *
 
+
 class DriverRequestParser:
 
     def __init__(self):
@@ -71,30 +72,31 @@ class DriverRequestParser:
         """
         for key, value in source.items():
 
-            if (isinstance(value, dict)):
+            if isinstance(value, dict):
                 created = self._create_object_of_type(value)
 
-                # if we are at deployment object , create custom model
+                # if we are at deployment object, create custom model
                 self._handle_deployment_custom_model(created, value)
                 set_value(result, key, created)
                 self._fill_recursive(value, getattr(result, key))
-            elif (isinstance(value, (list))):
 
-                    if(self._try_convert_to_attributes_dict(value, result, key)):
-                        continue
+            elif isinstance(value, (list)):
 
-                    created_arr = []
-                    set_value(result, key, created_arr)
+                if self._try_convert_to_attributes_dict(value, result, key):
+                    continue
 
-                    for item in value:
-                        if isinstance(item, (dict)):
-                            created_item = self._create_object_of_type(item)
-                            created_arr.append(created_item)
-                            self._fill_recursive(item, created_item)
-                        else:
-                            created_arr.append(item)
+                created_arr = []
+                set_value(result, key, created_arr)
 
-            else: # primitive value
+                for item in value:
+                    if isinstance(item, (dict)):
+                        created_item = self._create_object_of_type(item)
+                        created_arr.append(created_item)
+                        self._fill_recursive(item, created_item)
+                    else:
+                        created_arr.append(item)
+
+            else:  # primitive value
                 set_value(result, key, value)
 
     def _handle_deployment_custom_model(self, result, item):

--- a/package/cloudshell/cp/core/models.py
+++ b/package/cloudshell/cp/core/models.py
@@ -1,9 +1,13 @@
+from cloudshell.cp.core.requested_ips.parser import RequestedIPsParser
+
+
 class Printable:
     def __str__(self):
         return str(self.__class__) + ":\t" + str(self.__dict__)
 
     def __repr__(self):
         return str(self)
+
 
 # region base
 import json
@@ -47,13 +51,14 @@ class ConnectivityVlanActionBase(ConnectivityActionBase):
 # region Common
 
 class Attribute(RequestObjectBase):
-    def __init__(self,attributeName = '',attributeValue = ''):
+    def __init__(self, attributeName='', attributeValue=''):
         RequestObjectBase.__init__(self)
-        self.attributeName = attributeName    # type: str
+        self.attributeName = attributeName  # type: str
         self.attributeValue = attributeValue  # type: str
 
 
 # endregion
+
 # region DeployApp
 
 class DeployApp(RequestActionBase):
@@ -76,6 +81,13 @@ class DeployAppDeploymentInfo(RequestObjectBase):
         self.deploymentPath = ''  # type: str
         self.attributes = None  # type: dict
         self.customModel = None  # type: object
+        self._requested_ips = None  # type:
+
+    @property
+    def requested_ips(self):
+        if not self._requested_ips:
+            self._requested_ips = RequestedIPsParser.parse(self.attributes)
+        return self._requested_ips
 
 
 class AppResourceInfo(RequestObjectBase):
@@ -83,8 +95,8 @@ class AppResourceInfo(RequestObjectBase):
         RequestObjectBase.__init__(self)
         self.attributes = None  # type: dict
 
-
 # endregion
+
 # region CreateKeys
 
 class CreateKeys(RequestActionBase):
@@ -93,6 +105,7 @@ class CreateKeys(RequestActionBase):
 
 
 # endregion
+
 # region PrepareSubnet
 
 class PrepareSubnet(ConnectivityActionBase):
@@ -155,8 +168,8 @@ class ConnectToSubnetParams(RequestObjectBase):
     def __init__(self):
         RequestObjectBase.__init__(self)
         self.cidr = ''  # type: str
-        self.subnetId = ''                  # type: str
-        self.isPublic = True               # type: bool
+        self.subnetId = ''  # type: str
+        self.isPublic = True  # type: bool
         self.subnetServiceAttributes = None  # type: dict
         self.vnicName = ''  # type: str
 
@@ -189,13 +202,14 @@ class SaveApp(RequestActionBase):
 class SaveAppParams(RequestObjectBase):
     def __init__(self):
         RequestObjectBase.__init__(self)
-        self.saveDeploymentModel       = ''  # type: str
-        self.savedSandboxId            = ''  # type: str
-        self.sourceVmUuid              = ''  # type: str
-        self.sourceAppName             = ''  # type: str
-        self.deploymentPathAttributes  = []  # type: list[Attribute]
-# endregion
+        self.saveDeploymentModel = ''  # type: str
+        self.savedSandboxId = ''  # type: str
+        self.sourceVmUuid = ''  # type: str
+        self.sourceAppName = ''  # type: str
+        self.deploymentPathAttributes = []  # type: list[Attribute]
 
+
+# endregion
 
 # region Delete Saved Sandbox
 class DeleteSavedApp(RequestActionBase):
@@ -207,14 +221,15 @@ class DeleteSavedApp(RequestActionBase):
 class DeleteSavedAppParams(RequestObjectBase):
     def __init__(self):
         RequestObjectBase.__init__(self)
-        self.saveDeploymentModel       = ''  # type: str
-        self.savedSandboxId            = ''  # type: str
-        self.artifacts                 = []  # type: list[Artifact]
-        self.savedAppName              = ''  # type: str
+        self.saveDeploymentModel = ''  # type: str
+        self.savedSandboxId = ''  # type: str
+        self.artifacts = []  # type: list[Artifact]
+        self.savedAppName = ''  # type: str
+
+
 # endregion
 
 # region Traffic Mirroring
-
 
 class RemoveTrafficMirroring(RequestActionBase):
     def __init__(self):
@@ -258,11 +273,10 @@ class PortRange(RequestObjectBase):
 
 # endregion
 
-
 # region driver response
 
 class DriverResponseRoot(object):
-    def __init__(self,driverResponse = None):
+    def __init__(self, driverResponse=None):
         """
         :param driverResponse:  DriverResponse
         """
@@ -271,12 +285,13 @@ class DriverResponseRoot(object):
     def to_json(self):
         return json.dumps(self, default=lambda o: o.__dict__)
 
+
 class DriverResponse(object):
-    def __init__(self,actionResults = None):
+    def __init__(self, actionResults=None):
         """
         :param actionResults: [ActionResultBase]
         """
-        self.actionResults = actionResults if actionResults else [] # type: [ActionResultBase]
+        self.actionResults = actionResults if actionResults else []  # type: [ActionResultBase]
 
     def to_driver_response_json(self):
         """
@@ -285,9 +300,10 @@ class DriverResponse(object):
         """
         return DriverResponseRoot(driverResponse=self).to_json()
 
-#endregion
-# region actions results
 
+# endregion
+
+# region actions results
 
 class ActionResultBase:
     def __init__(self, type='', actionId='', success=True, infoMessage='', errorMessage=''):
@@ -298,11 +314,11 @@ class ActionResultBase:
         :param infoMessage:  str
         :param errorMessage: str
         """
-        self.type = type                 # type: str
-        self.actionId = actionId         # type: str
-        self.success = success           # type: bool
-        self.infoMessage = infoMessage   # type: str
-        self.errorMessage = errorMessage # type: str
+        self.type = type  # type: str
+        self.actionId = actionId  # type: str
+        self.success = success  # type: bool
+        self.infoMessage = infoMessage  # type: str
+        self.errorMessage = errorMessage  # type: str
 
 
 class DeployAppResult(ActionResultBase):
@@ -331,7 +347,7 @@ class DeployAppResult(ActionResultBase):
 
 
 class VmDetailsData(object):
-    def __init__(self, vmInstanceData=None, vmNetworkData=None,appName = '',errorMessage = ''):
+    def __init__(self, vmInstanceData=None, vmNetworkData=None, appName='', errorMessage=''):
         """
         :param vmInstanceData: [VmDetailsProperty]
         :param vmNetworkData:  [VmDetailsNetworkInterface]
@@ -343,6 +359,7 @@ class VmDetailsData(object):
         self.vmNetworkData = vmNetworkData if vmNetworkData else []  # type: [VmDetailsNetworkInterface]
         self.appName = appName
         self.errorMessage = errorMessage
+
 
 class VmDetailsProperty(object):
     def __init__(self, key='', value='', hidden=False):
@@ -357,7 +374,8 @@ class VmDetailsProperty(object):
 
 
 class VmDetailsNetworkInterface(object):
-    def __init__(self, interfaceId='', networkId='', isPrimary=False, isPredefined=False, networkData=None,privateIpAddress='',publicIpAddress=''):
+    def __init__(self, interfaceId='', networkId='', isPrimary=False, isPredefined=False, networkData=None,
+                 privateIpAddress='', publicIpAddress=''):
         """
         :param interfaceId:  str
         :param networkId:    str
@@ -416,18 +434,21 @@ class SaveAppResult(ActionResultBase):
         :param additionalData: list[DataElement]
         """
         ActionResultBase.__init__(self, 'SaveApp', actionId, success, infoMessage, errorMessage)
-        self.artifacts             = artifacts or []  # type: list[Artifact]
+        self.artifacts = artifacts or []  # type: list[Artifact]
         self.savedEntityAttributes = savedEntityAttributes or []
-        self.additionalData        = additionalData or []
+        self.additionalData = additionalData or []
+
 
 class SetVlanResult(ActionResultBase):
     def __init__(self, actionId='', success=True, infoMessage='', errorMessage='', updatedInterface=''):
         ActionResultBase.__init__(self, 'setVlan', actionId, success, infoMessage, errorMessage)
         self.updatedInterface = updatedInterface
 
+
 class RemoveVlanResult(ActionResultBase):
     def __init__(self, actionId='', success=True, infoMessage='', errorMessage=''):
         ActionResultBase.__init__(self, 'removeVlan', actionId, success, infoMessage, errorMessage)
+
 
 class CleanupNetworkResult(ActionResultBase):
     def __init__(self, actionId='', success=True, infoMessage='', errorMessage=''):
@@ -448,13 +469,13 @@ class RemoveTrafficMirroringResult(ActionResultBase):
 class Artifact(RequestObjectBase):
     def __init__(self, artifactRef='', artifactName=''):
         RequestObjectBase.__init__(self)
-        self.artifactRef   = artifactRef      # type str
-        self.artifactName  = artifactName     # type str
+        self.artifactRef = artifactRef  # type str
+        self.artifactName = artifactName  # type str
 
 
 class DataElement(object):
     def __init__(self, name, value):
-        self.name  = name
+        self.name = name
         self.value = value
 
 # endregion

--- a/package/cloudshell/cp/core/requested_ips/__init__.py
+++ b/package/cloudshell/cp/core/requested_ips/__init__.py
@@ -1,0 +1,3 @@
+__author__ = 'quali'
+from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)

--- a/package/cloudshell/cp/core/requested_ips/mapper.py
+++ b/package/cloudshell/cp/core/requested_ips/mapper.py
@@ -17,11 +17,11 @@ class RequestedIPsMapper:
         :param List[cloudshell.cp.core.models.ConnectSubnet] network_actions:
         :rtype: Dict[str, List[str]]
         """
-        cidrs = map(lambda x: x.actionParams.cidr, network_actions)
+        cidrs = list(map(lambda x: x.actionParams.cidr, network_actions))
         requested_ips_list_address_obj = \
-            map(lambda ips_for_nic:
-                (map(lambda x: ipaddress.ip_address(str(x)), ips_for_nic), ips_for_nic),
-                self._requested_ips_list)
+            list(map(lambda ips_for_nic:
+                (list(map(lambda x: ipaddress.ip_address(str(x)), ips_for_nic)), ips_for_nic),
+                self._requested_ips_list))
 
         cidrs_to_req_ips = {}
 

--- a/package/cloudshell/cp/core/requested_ips/mapper.py
+++ b/package/cloudshell/cp/core/requested_ips/mapper.py
@@ -1,5 +1,7 @@
+from __future__ import (absolute_import, division, print_function, unicode_literals)
+from builtins import str
+
 import ipaddress
-from typing import Dict, List
 
 
 class RequestedIPsMapper:
@@ -18,13 +20,13 @@ class RequestedIPsMapper:
         cidrs = map(lambda x: x.actionParams.cidr, network_actions)
         requested_ips_list_address_obj = \
             map(lambda ips_for_nic:
-                (map(lambda x: ipaddress.ip_address(unicode(x)), ips_for_nic), ips_for_nic),
+                (map(lambda x: ipaddress.ip_address(str(x)), ips_for_nic), ips_for_nic),
                 self._requested_ips_list)
 
         cidrs_to_req_ips = {}
 
         for subnet_cidr in cidrs:
-            subnet = ipaddress.ip_network(unicode(subnet_cidr))
+            subnet = ipaddress.ip_network(str(subnet_cidr))
 
             for ips_for_nic_ipaddress_obj, ips_for_nic in requested_ips_list_address_obj:
                 # check if all ips are in subnet

--- a/package/cloudshell/cp/core/requested_ips/mapper.py
+++ b/package/cloudshell/cp/core/requested_ips/mapper.py
@@ -1,0 +1,40 @@
+import ipaddress
+from typing import Dict, List
+
+
+class RequestedIPsMapper:
+
+    def __init__(self, requested_ips_list):
+        """
+        :param List[List[str]] requested_ips_list:
+        """
+        self._requested_ips_list = requested_ips_list
+
+    def map_network_to_requested_ips(self, network_actions):
+        """
+        :param List[cloudshell.cp.core.models.ConnectSubnet] network_actions:
+        :rtype: Dict[str, List[str]]
+        """
+        cidrs = map(lambda x: x.actionParams.cidr, network_actions)
+        requested_ips_list_address_obj = \
+            map(lambda ips_for_nic:
+                (map(lambda x: ipaddress.ip_address(unicode(x)), ips_for_nic), ips_for_nic),
+                self._requested_ips_list)
+
+        cidrs_to_req_ips = {}
+
+        for subnet_cidr in cidrs:
+            subnet = ipaddress.ip_network(unicode(subnet_cidr))
+
+            for ips_for_nic_ipaddress_obj, ips_for_nic in requested_ips_list_address_obj:
+                # check if all ips are in subnet
+                if all(ip in subnet for ip in ips_for_nic_ipaddress_obj):
+                    cidrs_to_req_ips[subnet_cidr] = ips_for_nic
+                    continue
+
+                # check if any ip is in subnet -> if true it means some IPs are outside of subnet range
+                # so need to raise error
+                if any(ip in subnet for ip in ips_for_nic_ipaddress_obj):
+                    raise ValueError('Some of the requested IPs are outside of network {}'.format(subnet_cidr))
+
+        return cidrs_to_req_ips

--- a/package/cloudshell/cp/core/requested_ips/parser.py
+++ b/package/cloudshell/cp/core/requested_ips/parser.py
@@ -1,0 +1,76 @@
+import ipaddress
+
+from cloudshell.cp.core.requested_ips.validator import RequestedIPsValidator
+
+PRIVATE_IP_ATTR = 'Private IP'
+
+
+class RequestedIPsParser:
+
+    @staticmethod
+    def parse(attributes):
+        """
+        Look for 'Private IP' attribute and parse it
+        :param dict attributes:
+        :rtype: list
+        :return: List[List[str]] - Each item in the list represents the IP addresses per specific nic.
+        """
+        ips_request_string = RequestedIPsParser._get_private_ip_attribute_value(attributes)
+        if not ips_request_string:
+            return None
+
+        requested_ips = []
+
+        for ip_req_for_nic in ips_request_string.split(';'):
+            requested_ips_for_nic = []
+            for ip_req_single in ip_req_for_nic.split(','):
+                ip_req_single = ip_req_single.strip()
+                if RequestedIPsValidator.is_range(ip_req_single):
+                    ip_in_range = RequestedIPsParser._parse_range(ip_req_single)
+                    requested_ips_for_nic.extend(ip_in_range)
+
+                else:
+                    RequestedIPsValidator.validate_ip_address(ip_req_single)
+                    requested_ips_for_nic.append(ip_req_single)
+
+            requested_ips.append(requested_ips_for_nic)
+
+        return requested_ips
+
+    @staticmethod
+    def _get_private_ip_attribute_value(attributes):
+        """
+        :param dict attributes:
+        :rtype: str
+        """
+        ips_request = None
+
+        if PRIVATE_IP_ATTR in attributes:
+            ips_request = attributes[PRIVATE_IP_ATTR]
+
+        else:
+            # try to get attribute using 2nd gen shell formatting
+            private_ip_attr_2nd_gen = '.' + PRIVATE_IP_ATTR
+            for attribute_name in attributes.keys():
+                if attribute_name.endswith(private_ip_attr_2nd_gen):
+                    ips_request = attributes[attribute_name]
+                    break
+
+        return ips_request
+
+    @staticmethod
+    def _parse_range(ip_req_single):
+        """
+        :param str ip_req_single:
+        :rtype: list
+        """
+        range_start, range_length = ip_req_single.split('-')
+        start_ip = ipaddress.ip_address(unicode(range_start))
+
+        ips_in_range = []
+        for i in range(0, int(range_length) + 1):
+            ips_in_range.append(str(start_ip + i))
+
+        return ips_in_range
+
+

--- a/package/cloudshell/cp/core/requested_ips/parser.py
+++ b/package/cloudshell/cp/core/requested_ips/parser.py
@@ -1,3 +1,6 @@
+from __future__ import (absolute_import, division, print_function, unicode_literals)
+from builtins import str
+
 import ipaddress
 
 from cloudshell.cp.core.requested_ips.validator import RequestedIPsValidator
@@ -65,7 +68,7 @@ class RequestedIPsParser:
         :rtype: list
         """
         range_start, range_length = ip_req_single.split('-')
-        start_ip = ipaddress.ip_address(unicode(range_start))
+        start_ip = ipaddress.ip_address(str(range_start))
 
         ips_in_range = []
         for i in range(0, int(range_length) + 1):

--- a/package/cloudshell/cp/core/requested_ips/validator.py
+++ b/package/cloudshell/cp/core/requested_ips/validator.py
@@ -6,7 +6,7 @@ import ipaddress
 class RequestedIPsValidator:
 
     @staticmethod
-    def validate_ip_address_range(ip_range):
+    def validate_ip_address_range_basic(ip_range):
         """
         :param str ip_range:
         """
@@ -30,17 +30,6 @@ class RequestedIPsValidator:
         except:
             raise_err('The range length is not a valid integer')
 
-        # 4. validate max length for range 'length'
-        if range_length > 253:
-            raise raise_err('The range max length is 253')
-
-        # 5. validate that all IPs in the range are legal
-        ip_range_start = ipaddress.ip_address(ip)
-        ip_range_end = ip_range_start + range_length
-        network = ipaddress.ip_network(ip[:ip.rfind('.')] + u'.0/24')
-        if ip_range_end not in network:
-            raise_err('Requested range is illegal. All IPs in the range should be in the same network')
-
     @staticmethod
     def validate_ip_address(ip):
         """
@@ -56,7 +45,7 @@ class RequestedIPsValidator:
         :rtype: bool
         """
         try:
-            RequestedIPsValidator.validate_ip_address_range(ip)
+            RequestedIPsValidator.validate_ip_address_range_basic(ip)
             return True
         except:
             return False

--- a/package/cloudshell/cp/core/requested_ips/validator.py
+++ b/package/cloudshell/cp/core/requested_ips/validator.py
@@ -1,0 +1,60 @@
+import ipaddress
+
+
+class RequestedIPsValidator:
+
+    @staticmethod
+    def validate_ip_address_range(ip_range):
+        """
+        :param str ip_range:
+        """
+        def raise_err(message):
+            raise ValueError('{}. {} is not a valid IP Address range. Valid example: 10.0.0.1-10'.format(message, ip_range))
+
+        # 1. validate basic structure
+        address_and_range = ip_range.split('-')
+        if not len(address_and_range) == 2:
+            raise_err('Missing delimiter')
+
+        ip = unicode(address_and_range[0])
+
+        # 2. validate that the IP address part of the range has a valid IP address
+        RequestedIPsValidator.validate_ip_address(ip)
+
+        # 3. validate the 'length' part of the range is a valid integer
+        range_length = 0
+        try:
+            range_length = int(address_and_range[1])
+        except:
+            raise_err('The range length is not a valid integer')
+
+        # 4. validate max length for range 'length'
+        if range_length > 253:
+            raise raise_err('The range max length is 253')
+
+        # 5. validate that all IPs in the range are legal
+        ip_range_start = ipaddress.ip_address(ip)
+        ip_range_end = ip_range_start + range_length
+        network = ipaddress.ip_network(ip[:ip.rfind('.')] + u'.0/24')
+        if ip_range_end not in network:
+            raise_err('Requested range is illegal. All IPs in the range should be in the same network')
+
+    @staticmethod
+    def validate_ip_address(ip):
+        """
+        :param str ip:
+        """
+        # if ip address is not valid the following line will raise an exception
+        ipaddress.ip_address(unicode(ip))
+
+    @staticmethod
+    def is_range(ip):
+        """
+        :param str ip:
+        :rtype: bool
+        """
+        try:
+            RequestedIPsValidator.validate_ip_address_range(ip)
+            return True
+        except:
+            return False

--- a/package/cloudshell/cp/core/requested_ips/validator.py
+++ b/package/cloudshell/cp/core/requested_ips/validator.py
@@ -1,3 +1,5 @@
+from __future__ import (absolute_import, division, print_function, unicode_literals)
+from builtins import str
 import ipaddress
 
 
@@ -16,7 +18,7 @@ class RequestedIPsValidator:
         if not len(address_and_range) == 2:
             raise_err('Missing delimiter')
 
-        ip = unicode(address_and_range[0])
+        ip = str(address_and_range[0])
 
         # 2. validate that the IP address part of the range has a valid IP address
         RequestedIPsValidator.validate_ip_address(ip)
@@ -45,7 +47,7 @@ class RequestedIPsValidator:
         :param str ip:
         """
         # if ip address is not valid the following line will raise an exception
-        ipaddress.ip_address(unicode(ip))
+        ipaddress.ip_address(str(ip))
 
     @staticmethod
     def is_range(ip):

--- a/package/cloudshell/cp/core/utils.py
+++ b/package/cloudshell/cp/core/utils.py
@@ -1,21 +1,21 @@
-from cloudshell.cp.core.models import DriverResponseRoot,DriverResponse,Attribute
+from cloudshell.cp.core.models import DriverResponseRoot, DriverResponse, Attribute
 
-def set_value(target, name, value, raise_exeception = False):
 
+def set_value(target, name, value, raise_exeception=False):
     if isinstance(target, (list)):
         target.append(value)
-    elif(not try_set_attr(target, name, value) and raise_exeception):
-        raise ValueError(target.__class__.__name__ +  ' has no property named ' + name)
+    elif (not try_set_attr(target, name, value) and raise_exeception):
+        raise ValueError(target.__class__.__name__ + ' has no property named ' + name)
+
 
 def convert_to_bool(v):
-
     if type(v) is bool:
         return v
 
     return v != None and v.lower() == "true"
 
-def try_set_attr(target, name, value):
 
+def try_set_attr(target, name, value):
     try:
         if (hasattr(target, name)):
             value = convert_to_bool(value) if type(getattr(target, name)) is bool else value
@@ -27,19 +27,23 @@ def try_set_attr(target, name, value):
 
     return False
 
-def get_class( kls ):
+
+def get_class(kls):
     parts = kls.split('.')
     module = ".".join(parts[:-1])
-    m = __import__( module )
+    m = __import__(module)
     for comp in parts[1:]:
         m = getattr(m, comp)
     return m
 
+
 def first_letter_to_upper(str):
     return str[:1].upper() + str[1:]
 
+
 def to_snake_case(str):
-    return  str.lower().replace(' ','_' )
+    return str.lower().replace(' ', '_')
+
 
 def first_or_default(lst, predicate):
     result = filter(predicate, lst)[:1]
@@ -48,6 +52,7 @@ def first_or_default(lst, predicate):
 
 def single(lst, predicate):
     return list(filter(predicate, lst))[0]
+
 
 def index_of(lst, predicate):
     gen = (index for index, item in enumerate(lst) if predicate(item))
@@ -59,8 +64,8 @@ def index_of(lst, predicate):
 
     return first
 
-def convert_attributes_list_to_dict(attributes):
 
+def convert_attributes_list_to_dict(attributes):
     attributes_map = {}
 
     # so we shall convert it to attributes map{key : attribute name,value : attribute value }
@@ -69,11 +74,11 @@ def convert_attributes_list_to_dict(attributes):
 
     return attributes_map
 
-def convert_dict_to_attributes_list(attributes_dict):
 
+def convert_dict_to_attributes_list(attributes_dict):
     attributes = []
 
-    for k,v in attributes_dict.iteritems():
-        attributes.append(Attribute(k,v))
+    for k, v in attributes_dict.iteritems():
+        attributes.append(Attribute(k, v))
 
     return attributes

--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -1,0 +1,2 @@
+future==0.18.2
+ipaddress==1.0.23

--- a/package/setup.py
+++ b/package/setup.py
@@ -4,6 +4,9 @@ import os
 with open(os.path.join('version.txt')) as version_file:
     version_from_file = version_file.read().strip()
 
+with open('requirements.txt') as f_required:
+    required = f_required.read().splitlines()
+
 setup(
         name="cloudshell-cp-core",
         author="Quali",
@@ -14,7 +17,7 @@ setup(
         packages=find_packages(),
         test_suite='nose.collector',
         package_data={'': ['*.txt']},
-        install_requires=[],
+        install_requires=required,
         version=version_from_file,
         include_package_data=True,
         keywords="sandbox cloudshell json request",

--- a/package/tests/test_cloudshell_cp_core.py
+++ b/package/tests/test_cloudshell_cp_core.py
@@ -5,6 +5,7 @@ from cloudshell.cp.core.models import *
 from cloudshell.cp.core.utils import *
 import json
 
+
 class TestCloudShellCpCore(TestCase):
 
     def test_custom_deployment_model(self):
@@ -30,7 +31,6 @@ class TestCloudShellCpCore(TestCase):
         self.assertTrue(action.actionParams.deployment.customModel.auto_power_off, 'True')
 
     def test_custom_deployment_model_slicker(self):
-
         # prepare
         class CustomModel(object):
             __deploymentModel__ = "VCenter Deploy VM From Linked Clone"
@@ -38,7 +38,6 @@ class TestCloudShellCpCore(TestCase):
             def __init__(self, attributes):
                 self.auto_power_off = False
                 self.autoload = ''
-
 
                 for k, v in attributes.items():
                     try_set_attr(self, to_snake_case(k), v)
@@ -56,7 +55,6 @@ class TestCloudShellCpCore(TestCase):
         self.assertEqual(action.actionParams.deployment.customModel.autoload, 'True')
         self.assertEqual(action.actionParams.deployment.customModel.auto_power_off, True)
 
-
     def test_deploy_app_action(self):
         # prepare
         json_req = '{"driverRequest":{"actions":[{"actionParams":{"appName":"vCenter_CVC_Support","deployment":{"deploymentPath":"VCenter Deploy VM From Linked Clone","attributes":[{"attributeName":"vCenter VM","attributeValue":"Tor/Temps/ImageMonoNew","type":"attribute"},{"attributeName":"vCenter VM Snapshot","attributeValue":"1","type":"attribute"},{"attributeName":"VM Cluster","attributeValue":"","type":"attribute"},{"attributeName":"VM Storage","attributeValue":"","type":"attribute"},{"attributeName":"VM Resource Pool","attributeValue":"","type":"attribute"},{"attributeName":"VM Location","attributeValue":"","type":"attribute"},{"attributeName":"Auto Power On","attributeValue":"True","type":"attribute"},{"attributeName":"Auto Power Off","attributeValue":"True","type":"attribute"},{"attributeName":"Wait for IP","attributeValue":"True","type":"attribute"},{"attributeName":"Auto Delete","attributeValue":"True","type":"attribute"},{"attributeName":"Autoload","attributeValue":"True","type":"attribute"},{"attributeName":"IP Regex","attributeValue":"","type":"attribute"},{"attributeName":"Refresh IP Timeout","attributeValue":"600","type":"attribute"}],"type":"deployAppDeploymentInfo"},"appResource":{"attributes":[{"attributeName":"Password","attributeValue":"3M3u7nkDzxWb0aJ/IZYeWw==","type":"attribute"},{"attributeName":"Public IP","attributeValue":"","type":"attribute"},{"attributeName":"User","attributeValue":"","type":"attribute"}],"type":"appResourceInfo"},"type":"deployAppParams"},"actionId":"ad3561c1-45a5-445a-9b5f-4021879a0b0c","type":"deployApp"}]}}'
@@ -71,7 +69,6 @@ class TestCloudShellCpCore(TestCase):
         self.assertEqual(deploy_action.actionParams.deployment.deploymentPath, "VCenter Deploy VM From Linked Clone")
         self.assertEqual(deploy_action.actionParams.deployment.attributes["vCenter VM Snapshot"], "1")
 
-
     def test_prepare_connectivity_action(self):
         # prepare
         json_req = '{"driverRequest":{"actions":[{"actionParams":{"cidr":"10.0.1.0/24","type":"prepareCloudInfraParams"},"actionId":"36af5bbf-c9b4-4e5d-b84b-9ea513c7defd","type":"prepareCloudInfra"},{"actionParams":{"isPublic":true,"cidr":"10.0.1.0/24","alias":"DefaultSubnet","subnetServiceAttributes":null,"type":"prepareSubnetParams"},"actionTarget":{"fullName":null,"fullAddress":null,"type":"actionTarget"},"actionId":"0480fa41-f50b-42d6-9c0d-5518875f1176","type":"prepareSubnet"}]}}'
@@ -81,13 +78,13 @@ class TestCloudShellCpCore(TestCase):
         parser = DriverRequestParser()
         actions = parser.convert_driver_request_to_actions(req)
         self.assertEqual(len(actions), 2)
-        prepare_cloud_infra = single(actions,lambda x: isinstance(x,PrepareCloudInfra))
+        prepare_cloud_infra = single(actions, lambda x: isinstance(x, PrepareCloudInfra))
 
         # assert
         self.assertEqual(prepare_cloud_infra.actionId, '36af5bbf-c9b4-4e5d-b84b-9ea513c7defd')
         self.assertEqual(prepare_cloud_infra.actionParams.cidr, '10.0.1.0/24')
 
-        prepare_subnet = single(actions,lambda x: isinstance(x,PrepareSubnet ))
+        prepare_subnet = single(actions, lambda x: isinstance(x, PrepareSubnet))
 
         self.assertEqual(prepare_subnet.actionParams.alias, 'DefaultSubnet')
         self.assertEqual(prepare_subnet.actionParams.isPublic, True)
@@ -121,8 +118,6 @@ class TestCloudShellCpCore(TestCase):
         # assert
         self.assertIsInstance(remove_vlan_actions[0], SetVlan)
 
-
-
     def test_parse_json_serialized_request(self):
         # prepare
         json_req = '{"driverRequest":{"actions":[{"actionParams":{"appName":"vCenter_CVC_Support","deployment":{"deploymentPath":"VCenter Deploy VM From Linked Clone","attributes":[{"attributeName":"vCenter VM","attributeValue":"Tor/Temps/ImageMonoNew","type":"attribute"},{"attributeName":"vCenter VM Snapshot","attributeValue":"1","type":"attribute"},{"attributeName":"VM Cluster","attributeValue":"","type":"attribute"},{"attributeName":"VM Storage","attributeValue":"","type":"attribute"},{"attributeName":"VM Resource Pool","attributeValue":"","type":"attribute"},{"attributeName":"VM Location","attributeValue":"","type":"attribute"},{"attributeName":"Auto Power On","attributeValue":"True","type":"attribute"},{"attributeName":"Auto Power Off","attributeValue":"True","type":"attribute"},{"attributeName":"Wait for IP","attributeValue":"True","type":"attribute"},{"attributeName":"Auto Delete","attributeValue":"True","type":"attribute"},{"attributeName":"Autoload","attributeValue":"True","type":"attribute"},{"attributeName":"IP Regex","attributeValue":"","type":"attribute"},{"attributeName":"Refresh IP Timeout","attributeValue":"600","type":"attribute"}],"type":"deployAppDeploymentInfo"},"appResource":{"attributes":[{"attributeName":"Password","attributeValue":"3M3u7nkDzxWb0aJ/IZYeWw==","type":"attribute"},{"attributeName":"Public IP","attributeValue":"","type":"attribute"},{"attributeName":"User","attributeValue":"","type":"attribute"}],"type":"appResourceInfo"},"type":"deployAppParams"},"actionId":"ad3561c1-45a5-445a-9b5f-4021879a0b0c","type":"deployApp"}]}}'
@@ -136,7 +131,6 @@ class TestCloudShellCpCore(TestCase):
         self.assertEqual(actions[0].actionParams.appName, 'vCenter_CVC_Support')
 
     def test_try_set_attr(self):
-
         class CustomModel(object):
             __deploymentModel__ = "VCenter Deploy VM From Linked Clone"
 

--- a/package/tests/test_requested_ips_mapper.py
+++ b/package/tests/test_requested_ips_mapper.py
@@ -1,0 +1,53 @@
+import unittest
+
+from mock import Mock
+
+from cloudshell.cp.core.requested_ips.mapper import RequestedIPsMapper
+
+
+class TestRequestedIPsMapper(unittest.TestCase):
+
+    def test_map_network_to_requested_ips_successfully(self):
+        # arrange
+        requested_ips_for_subnet1 = ['10.0.0.5', '10.0.0.8']
+        requested_ips_for_subnet2 = ['10.0.0.20', '10.0.0.21', '10.0.0.22']
+        requested_ips_list = [requested_ips_for_subnet1, requested_ips_for_subnet2]
+        mapper = RequestedIPsMapper(requested_ips_list)
+
+        action1 = Mock()
+        cidr1 = '10.0.0.0/28'
+        action1.actionParams.cidr = cidr1
+        action2 = Mock()
+        cidr2 = '10.0.0.16/28'
+        action2.actionParams.cidr = cidr2
+        network_actions = [action1, action2]
+
+        # act
+        result = mapper.map_network_to_requested_ips(network_actions)
+
+        # assert
+        self.assertTrue(cidr1 in result)
+        self.assertTrue(cidr2 in result)
+        self.assertListEqual(requested_ips_for_subnet1, result.get(cidr1))
+        self.assertListEqual(requested_ips_for_subnet2, result.get(cidr2))
+
+    def test_map_network_to_requested_ips_error_req_ip_out_of_range(self):
+        # arrange
+        requested_ips_for_subnet1 = ['10.0.0.5', '10.0.0.18']
+        requested_ips_for_subnet2 = ['10.0.0.20', '10.0.0.21', '10.0.0.22']
+        requested_ips_list = [requested_ips_for_subnet1, requested_ips_for_subnet2]
+        mapper = RequestedIPsMapper(requested_ips_list)
+
+        action1 = Mock()
+        cidr1 = '10.0.0.0/28'
+        action1.actionParams.cidr = cidr1
+        action2 = Mock()
+        cidr2 = '10.0.0.16/28'
+        action2.actionParams.cidr = cidr2
+        network_actions = [action1, action2]
+
+        # act & assert
+        with self.assertRaisesRegexp(ValueError, 'outside of network 10.0.0.0/28'):
+            mapper.map_network_to_requested_ips(network_actions)
+
+

--- a/package/tests/test_requested_ips_parser.py
+++ b/package/tests/test_requested_ips_parser.py
@@ -1,0 +1,101 @@
+import unittest
+
+from mock import MagicMock
+
+from cloudshell.cp.core.requested_ips.parser import RequestedIPsParser
+
+
+class TestRequestedIPsParser(unittest.TestCase):
+
+    def test_parser_single_ip(self):
+        # arrange
+        attributes = {'Private IP': '10.0.0.1'}
+
+        # act
+        result = RequestedIPsParser.parse(attributes)
+
+        # assert
+        self.assertListEqual(result, [['10.0.0.1']])
+
+    def test_parser_single_range(self):
+        # arrange
+        attributes = {'Private IP': '10.0.0.10-4'}
+
+        # act
+        result = RequestedIPsParser.parse(attributes)
+
+        # assert
+        self.assertListEqual(result, [['10.0.0.10', '10.0.0.11', '10.0.0.12', '10.0.0.13', '10.0.0.14']])
+
+    def test_parser_multiple_ips_single_nic(self):
+        # arrange
+        attributes = {'Private IP': '10.0.0.1,10.0.0.5,10.0.0.7'}
+
+        # act
+        result = RequestedIPsParser.parse(attributes)
+
+        # assert
+        self.assertListEqual(result, [['10.0.0.1', '10.0.0.5', '10.0.0.7']])
+
+    def test_parser_multiple_ips_and_multiple_ranges_single_nic(self):
+        # arrange
+        attributes = {'Private IP': '10.0.0.1,10.0.0.5,10.0.0.7-3,10.0.0.20-2'}
+
+        # act
+        result = RequestedIPsParser.parse(attributes)
+
+        # assert
+        self.assertListEqual(result, [['10.0.0.1', '10.0.0.5', '10.0.0.7', '10.0.0.8', '10.0.0.9', '10.0.0.10',
+                                       '10.0.0.20', '10.0.0.21', '10.0.0.22']])
+
+    def test_parser_single_ip_multiple_nics(self):
+        # arrange
+        attributes = {'Private IP': '10.0.0.1;10.0.0.100;10.0.0.200'}
+
+        # act
+        result = RequestedIPsParser.parse(attributes)
+
+        # assert
+        self.assertListEqual(result, [['10.0.0.1'], ['10.0.0.100'], ['10.0.0.200']])
+
+    def test_parser_multiple_ips_and_multiple_ranges__for_multiple_nics(self):
+        # arrange
+        attributes = {'Private IP': '10.0.0.1,10.0.0.3,10.0.0.10-2;10.0.0.100-4;10.0.0.200-2,10.0.0.210'}
+
+        # act
+        result = RequestedIPsParser.parse(attributes)
+
+        # assert
+        self.assertListEqual(result, [['10.0.0.1', '10.0.0.3', '10.0.0.10', '10.0.0.11', '10.0.0.12'],
+                                      ['10.0.0.100', '10.0.0.101', '10.0.0.102', '10.0.0.103', '10.0.0.104'],
+                                      ['10.0.0.200', '10.0.0.201', '10.0.0.202', '10.0.0.210']])
+
+    def test_parser_with_spaces_between_delimiter(self):
+        # arrange
+        attributes = {'Private IP': '10.0.0.1, 10.0.0.10-2; 10.0.0.100-4 ; 10.0.0.200 , 10.0.0.210 ,10.0.0.214'}
+
+        # act
+        result = RequestedIPsParser.parse(attributes)
+
+        # assert
+        self.assertListEqual(result, [['10.0.0.1', '10.0.0.10', '10.0.0.11', '10.0.0.12'],
+                                      ['10.0.0.100', '10.0.0.101', '10.0.0.102', '10.0.0.103', '10.0.0.104'],
+                                      ['10.0.0.200', '10.0.0.210', '10.0.0.214']])
+
+    def test_parse_throws_ip_address_not_valid(self):
+        # arrange
+        attributes = {'Private IP': '10.0.0.300'}  # ip address is not valid
+
+        # act & assert
+        with self.assertRaises(ValueError):
+            RequestedIPsParser.parse(attributes)
+
+    def test_parser_no_private_ip_attribute(self):
+        # arrange
+        attributes = MagicMock()
+
+        # act
+        result = RequestedIPsParser.parse(attributes)
+
+        # assert
+        self.assertIsNone(result)

--- a/package/tests/test_requested_ips_validator.py
+++ b/package/tests/test_requested_ips_validator.py
@@ -1,0 +1,93 @@
+import unittest
+
+from mock import Mock, patch
+
+from cloudshell.cp.core.requested_ips.validator import RequestedIPsValidator
+
+
+class TestRequestedIPsValidator(unittest.TestCase):
+
+    def test_validate_ip_address_passes(self):
+        # arrange
+        ip = '10.0.0.1'
+
+        # act
+        RequestedIPsValidator.validate_ip_address(ip)
+
+    def test_validate_ip_address_failes(self):
+        # arrange
+        ip = '10.0.0.350'
+
+        # act & assert
+        with self.assertRaises(ValueError):
+            RequestedIPsValidator.validate_ip_address(ip)
+
+    @patch('cloudshell.cp.core.requested_ips.validator.RequestedIPsValidator.validate_ip_address_range')
+    def test_is_range_true(self, validate_ip_address_range_mock):
+        # arrange
+        ip = Mock()
+
+        # act
+        result = RequestedIPsValidator.is_range(ip)
+
+        # assert
+        self.assertTrue(result)
+
+    @patch('cloudshell.cp.core.requested_ips.validator.RequestedIPsValidator.validate_ip_address_range')
+    def test_is_range_false(self, validate_ip_address_range_mock):
+        # arrange
+        ip = Mock()
+        validate_ip_address_range_mock.side_effect = ValueError
+
+        # act
+        result = RequestedIPsValidator.is_range(ip)
+
+        # assert
+        self.assertFalse(result)
+
+    def test_validate_ip_address_range_passes(self):
+        # arrange
+        range = '10.0.0.1-10'
+
+        # act
+        RequestedIPsValidator.validate_ip_address_range(range)
+
+    def test_validate_ip_address_range_error_basic_structure(self):
+        # arrange
+        range = '10.0.0.1'  # no '-' to specify range
+
+        # act & assert
+        with self.assertRaisesRegexp(ValueError, 'Missing delimiter'):
+            RequestedIPsValidator.validate_ip_address_range(range)
+
+    def test_validate_ip_address_range_error_ip_address_invalid(self):
+        # arrange
+        range = 'xxx-20'  # no '-' to specify range
+
+        # act & assert
+        with self.assertRaises(ValueError):
+            RequestedIPsValidator.validate_ip_address_range(range)
+
+    def test_validate_ip_address_range_error_range_length_not_int(self):
+        # arrange
+        range = '10.0.0.1-xx'  # range length must be integer
+
+        # act & assert
+        with self.assertRaisesRegexp(ValueError, 'range length is not a valid integer'):
+            RequestedIPsValidator.validate_ip_address_range(range)
+
+    def test_validate_ip_address_range_error_range_length_too_big(self):
+        # arrange
+        range = '10.0.0.1-254'  # max range length is 253
+
+        # act & assert
+        with self.assertRaisesRegexp(ValueError, 'range max length is 253'):
+            RequestedIPsValidator.validate_ip_address_range(range)
+
+    def test_validate_ip_address_range_error_range_request_legal(self):
+        # arrange
+        range = '10.0.0.250-20'  # some of the ips in the requested range are outside of the network
+
+        # act & assert
+        with self.assertRaisesRegexp(ValueError, 'Requested range is illegal'):
+            RequestedIPsValidator.validate_ip_address_range(range)

--- a/package/tests/test_requested_ips_validator.py
+++ b/package/tests/test_requested_ips_validator.py
@@ -22,7 +22,7 @@ class TestRequestedIPsValidator(unittest.TestCase):
         with self.assertRaises(ValueError):
             RequestedIPsValidator.validate_ip_address(ip)
 
-    @patch('cloudshell.cp.core.requested_ips.validator.RequestedIPsValidator.validate_ip_address_range')
+    @patch('cloudshell.cp.core.requested_ips.validator.RequestedIPsValidator.validate_ip_address_range_basic')
     def test_is_range_true(self, validate_ip_address_range_mock):
         # arrange
         ip = Mock()
@@ -33,7 +33,7 @@ class TestRequestedIPsValidator(unittest.TestCase):
         # assert
         self.assertTrue(result)
 
-    @patch('cloudshell.cp.core.requested_ips.validator.RequestedIPsValidator.validate_ip_address_range')
+    @patch('cloudshell.cp.core.requested_ips.validator.RequestedIPsValidator.validate_ip_address_range_basic')
     def test_is_range_false(self, validate_ip_address_range_mock):
         # arrange
         ip = Mock()
@@ -50,7 +50,7 @@ class TestRequestedIPsValidator(unittest.TestCase):
         range = '10.0.0.1-10'
 
         # act
-        RequestedIPsValidator.validate_ip_address_range(range)
+        RequestedIPsValidator.validate_ip_address_range_basic(range)
 
     def test_validate_ip_address_range_error_basic_structure(self):
         # arrange
@@ -58,7 +58,7 @@ class TestRequestedIPsValidator(unittest.TestCase):
 
         # act & assert
         with self.assertRaisesRegexp(ValueError, 'Missing delimiter'):
-            RequestedIPsValidator.validate_ip_address_range(range)
+            RequestedIPsValidator.validate_ip_address_range_basic(range)
 
     def test_validate_ip_address_range_error_ip_address_invalid(self):
         # arrange
@@ -66,7 +66,7 @@ class TestRequestedIPsValidator(unittest.TestCase):
 
         # act & assert
         with self.assertRaises(ValueError):
-            RequestedIPsValidator.validate_ip_address_range(range)
+            RequestedIPsValidator.validate_ip_address_range_basic(range)
 
     def test_validate_ip_address_range_error_range_length_not_int(self):
         # arrange
@@ -74,20 +74,4 @@ class TestRequestedIPsValidator(unittest.TestCase):
 
         # act & assert
         with self.assertRaisesRegexp(ValueError, 'range length is not a valid integer'):
-            RequestedIPsValidator.validate_ip_address_range(range)
-
-    def test_validate_ip_address_range_error_range_length_too_big(self):
-        # arrange
-        range = '10.0.0.1-254'  # max range length is 253
-
-        # act & assert
-        with self.assertRaisesRegexp(ValueError, 'range max length is 253'):
-            RequestedIPsValidator.validate_ip_address_range(range)
-
-    def test_validate_ip_address_range_error_range_request_legal(self):
-        # arrange
-        range = '10.0.0.250-20'  # some of the ips in the requested range are outside of the network
-
-        # act & assert
-        with self.assertRaisesRegexp(ValueError, 'Requested range is illegal'):
-            RequestedIPsValidator.validate_ip_address_range(range)
+            RequestedIPsValidator.validate_ip_address_range_basic(range)


### PR DESCRIPTION
- add 'requested_ips' property to DeployApp class which uses the parser to process the value in 'Private IP' attribute
- add a utility mapper object to easily map between cidrs in network actions to requested ips
- some code cleanups

Closes #55

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/cloudshell-cp-core/56)
<!-- Reviewable:end -->
