### PR TITLE
Upgrade: Expand versions allowed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-attrs~=21.4
-jsonpickle~=1.4.1
+attrs>=21.4
+jsonpickle>=1.4.1
 cached-property~=1.5 ; python_version <= "3.8"
 cryptography>=2.9.2,<3.3 ; python_version <= "3.7"
-cryptography>=3.3,<37 ; python_version > "3.7"
+cryptography>=3.3 ; python_version > "3.7"


### PR DESCRIPTION
This library is growing hard to use as the requirements are locked to old versions.